### PR TITLE
Remove tk-multi-pythonconsole to 2018.3 and up

### DIFF
--- a/env/project.2018.3.yml
+++ b/env/project.2018.3.yml
@@ -23,7 +23,6 @@ engines:
     apps:
       tk-flame-review: '@ref_tk-flame-review'
       tk-multi-loader2: '@ref_tk-multi-loader2'
-      tk-multi-pythonconsole: '@ref_tk-multi-pythonconsole'
       tk-multi-shotgunpanel: '@ref_tk-multi-shotgunpanel'
       tk-flame-projectconnect: "@ref_tk-flame-projectconnect"
     location: '@ref_tk-flame_location'


### PR DESCRIPTION
JIRA: SMOK-46247

DESCRIPTION

Since Flame 2018.3 ships with a Python Console, we don‘t need the
Shotgun Python Console anymore.