### PR TITLE
Revert to tk-framework-shotgunutils v5.9.1

### DIFF
--- a/env/include/defs.yml
+++ b/env/include/defs.yml
@@ -120,6 +120,6 @@ ref_tk-flame_frameworks:
       name: tk-framework-qtwidgets
   tk-framework-shotgunutils_v5.x.x:
     location:
-      version: v5.10.0
+      version: v5.9.1
       type: app_store
       name: tk-framework-shotgunutils


### PR DESCRIPTION
JIRA: SG-35731
Flame crashes when publishing using FPTR with zero config

Until proper fix can be done in tk-framework-shotgunutils, stick to v5.9.1.