### PR TITLE
Revert "Revert to tk-framework-shotgunutils v5.9.1 (#60)"

### DIFF
--- a/env/include/defs.yml
+++ b/env/include/defs.yml
@@ -120,6 +120,6 @@ ref_tk-flame_frameworks:
       name: tk-framework-qtwidgets
   tk-framework-shotgunutils_v5.x.x:
     location:
-      version: v5.9.1
+      version: v5.10.0
       type: app_store
       name: tk-framework-shotgunutils


### PR DESCRIPTION
This reverts commit 4988697a757b1748ff058440aa4d006b8bb62714.

JIRA: SG-35731
Flame crashes when publishing using FPTR with zero config

The bug was caused by the 1.10.3 config being generated during the automatic update of the component. The update not being complete caused the crash.