### PR TITLE
SG-43667 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,6 @@ repos:
     - id: check-yaml
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black

--- a/info.yml
+++ b/info.yml
@@ -17,3 +17,4 @@ description: "Configuration for Toolkit based workflows."
 # Required minimum versions for this item to run
 requires_shotgun_version: "v6.3.0"
 requires_core_version: "v0.18.122"
+minimum_python_version: "3.9"


### PR DESCRIPTION
## Summary

- Set `minimum_python_version: "3.9"` in `info.yml`

## Test plan

- [ ] Config loads correctly with Python 3.9+

🤖 Generated with [Claude Code](https://claude.com/claude-code)